### PR TITLE
Add sales history and warehouse quantity editing

### DIFF
--- a/templates/buy/edit.html
+++ b/templates/buy/edit.html
@@ -47,7 +47,7 @@
 
     <div class="form-group">
         <label for="quantity">Количество</label>
-        <input type="number" id="quantity" name="quantity" value="{{ item.quantity }}" required>
+        <input type="number" id="quantity" name="quantity" value="{{ item.quantity }}" readonly>
     </div>
 
     <div class="form-group">

--- a/templates/history/index.html
+++ b/templates/history/index.html
@@ -1,0 +1,43 @@
+{% extends 'layout.html' %}
+
+{% block title %}История продаж{% endblock %}
+
+{% block content %}
+<div class="content-card">
+    <h1 class="welcome-title">📖 История продаж</h1>
+    <form method="get" class="form-grid filter-section">
+        <div class="form-group">
+            <label for="from">От:</label>
+            <input type="date" id="from" name="from" value="{{ from_date }}">
+        </div>
+        <div class="form-group">
+            <label for="to">До:</label>
+            <input type="date" id="to" name="to" value="{{ to_date }}">
+        </div>
+        <div class="form-group">
+            <label>&nbsp;</label>
+            <button type="submit" class="btn small-btn">🔍</button>
+        </div>
+    </form>
+    <table>
+        <thead>
+            <tr>
+                <th>Товар</th>
+                <th>Количество</th>
+                <th>Цена</th>
+                <th>Дата</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in rows %}
+            <tr>
+                <td>{{ row.name }}</td>
+                <td>{{ row.quantity }}</td>
+                <td>{{ '{:,.0f}'.format(row.price) }} $</td>
+                <td>{{ row.date }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -14,6 +14,7 @@
         <li><a href="{{ url_for('categories_index') }}">Категории</a></li>
         <li><a href="{{ url_for('countries_index') }}">Страны</a></li>
         <li><a href="{{ url_for('revision_index') }}">Ревизия</a></li>
+        <li><a href="{{ url_for('history_index') }}">История</a></li>
     </ul>
 
     {% with flash_messages = get_flashed_messages() %}

--- a/templates/revision/index.html
+++ b/templates/revision/index.html
@@ -15,7 +15,7 @@
     </div>
     <div class="form-group">
         <label>&nbsp;</label>
-        <button type="submit" class="button">🔍</button>
+        <button type="submit" class="btn small-btn">🔍</button>
     </div>
     <div class="form-group ">
         <label>&nbsp;</label>

--- a/templates/warehouse/edit.html
+++ b/templates/warehouse/edit.html
@@ -1,0 +1,19 @@
+{% extends 'layout.html' %}
+
+{% block title %}Изменить остаток{% endblock %}
+
+{% block content %}
+<div class="content-card">
+    <h1 class="welcome-title">✏️ Изменить остаток</h1>
+    <form method="post" class="form-grid">
+        <div class="form-group">
+            <label for="quantity">Количество</label>
+            <input type="number" id="quantity" name="quantity" value="{{ item.quantity }}" required>
+        </div>
+        <div class="form-group">
+            <label>&nbsp;</label>
+            <button type="submit" class="nav-button">💾 Сохранить</button>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/templates/warehouse/index.html
+++ b/templates/warehouse/index.html
@@ -7,12 +7,11 @@
     <h1 class="welcome-title">📦 Остатки на складе</h1>
     <table>
         <thead>
-
-
             <tr>
                 <th>Товар</th>
                 <th>Категория</th>
                 <th>Количество</th>
+                <th>Действия</th>
             </tr>
         </thead>
         <tbody>
@@ -22,7 +21,7 @@
                 <td>{{ item.category_name }}</td>
                 <td>{{ item.quantity }}</td>
                 <td>
-                    <a href="{{ url_for('sales_history', equipment_id=row['id']) }}" class="btn">📖 История</a>
+                    <a href="{{ url_for('warehouse_edit', item_id=item['id']) }}" class="button-link">Изменить</a>
                 </td>
             </tr>
             {% endfor %}


### PR DESCRIPTION
## Summary
- disable editing of quantity for purchase records
- allow updating quantity directly from warehouse
- add sales history page with date filters
- improve revision page buttons
- add new navigation link

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684b50bd92448324ab7adb5e95feb338