### PR TITLE
Hide navbar on login page

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -7,6 +7,10 @@ body {
     color: #2c3e50;
 }
 
+body.login-page {
+    padding-top: 0;
+}
+
 /* Меню */
 .navbar {
     display: flex;

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -6,7 +6,8 @@
     <title>{% block title %}Система управления складом{% endblock %}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 </head>
-<body>
+<body{% if request.endpoint == 'login' %} class="login-page"{% endif %}>
+    {% if request.endpoint != 'login' %}
     <nav class="navbar">
         <div class="burger">&#9776;</div>
         <ul class="nav-links">
@@ -30,6 +31,7 @@
             {% endif %}
         </ul>
     </nav>
+    {% endif %}
 
     {% with flash_messages = get_flashed_messages() %}
         {% if flash_messages %}


### PR DESCRIPTION
## Summary
- hide navigation bar on login page
- add body class to remove padding for login page

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684c66c5da308324a42fa16edda1598a